### PR TITLE
Publish a code coverage report to sonarqube

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -25,17 +25,17 @@ jobs:
 
       - name: Diag
         env:
+          SONAR_URL: http://sonarqube.lzaycomputing.net:9000
           SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}
           SONAR_PROJECT_KEY: ${{ env.SONAR_PROJECT_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          ./gradlew --version
-          ./gradlew tasks --all
+          echo "SONAR_URL: $SONAR_URL"
           echo "SONAR_HOST_URL: $SONAR_HOST_URL"
-          echo "SONAR_TOKEN: $SONAR_TOKEN"
+          echo "SONAR_PROJECT_KEY: $SONAR_PROJECT_KEY"
           echo "GITHUB_TOKEN: $GITHUB_TOKEN"
-          echo "SONAR_PROJECT_KEY: $SONAR_PROJECT_KEY"          
+          echo "SONAR_TOKEN: $SONAR_TOKEN"
 
       - name: Build and analyze
         env:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -23,25 +23,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Diag
-        env:
-          SONAR_URL: 'http://sonarqube.lzaycomputing.net:9000'
-          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
-          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          echo "SONAR_URL: $SONAR_URL"
-          echo "SONAR_HOST_URL: $SONAR_HOST_URL"
-          echo "SONAR_PROJECT_KEY: $SONAR_PROJECT_KEY"
-          echo "GITHUB_TOKEN: $GITHUB_TOKEN"
-          echo "SONAR_TOKEN: $SONAR_TOKEN"
-
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ vars.SONAR_TOKEN }}
         run: ./gradlew test jacocoTestReport sonar
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -23,6 +23,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Test SonarQube connection
+        env:
+          SONAR_TOKEN: ${{ vars.SONAR_TOKEN }}
+        run: |
+          curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -27,7 +27,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ vars.SONAR_TOKEN }}
         run: |
-          curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
+          curl -D - -u sqp_ab9e5c1b13f63215f8a2beb3a2aacfb7f7cf8d08: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
 
       - name: Build and analyze
         env:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,27 @@
+name: Build and SonarQube Analysis
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  sonar:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # Fetch all history for accurate blame info:contentReference[oaicite:1]{index=1}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Build and analyze
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN:    ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew test jacocoTestReport sonar

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -38,14 +38,6 @@ jobs:
           curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
           echo "Sonar project key: $SONAR_PROJECT_KEY"
 
-      - name: Test sonar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          ./gradlew test jacocoTestReport sonar -Dsonar.projectKey=Test01 -Dsonar.host.url=${{ vars.SONAR_HOST_URL }} -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Dsonar.verbose=true
-
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,6 +45,3 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
         run: ./gradlew test jacocoTestReport sonar -Dsonar.projectKey=Test01
-
-
-

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -39,10 +39,21 @@ jobs:
           curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
           echo "Sonar project key: $SONAR_PROJECT_KEY"
 
+      - name: Test sonar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          ./gradlew sonar -Dsonar.projectKey=Test01 -Dsonar.host.url=${{ vars.SONAR_HOST_URL }} -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Dsonar.verbose=true
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-        run: ./gradlew test jacocoTestReport sonar
+        run: ./gradlew test jacocoTestReport sonar -Dsonar.projectKey=Test01
+
+
+

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -23,8 +23,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Diag
+        run: |
+          ./gradlew --version
+          ./gradlew tasks --all
+
       - name: Build and analyze
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_TOKEN:    ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew test jacocoTestReport sonar
+

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Diag
         env:
-          SONAR_URL: http://sonarqube.lzaycomputing.net:9000
-          SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}
-          SONAR_PROJECT_KEY: ${{ env.SONAR_PROJECT_KEY }}
+          SONAR_URL: 'http://sonarqube.lzaycomputing.net:9000'
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -20,6 +20,9 @@ jobs:
           java-version: 21
           distribution: 'temurin'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Build and analyze
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -30,18 +30,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Test SonarQube connection
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-        run: |
-          curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
-          echo "Sonar project key: $SONAR_PROJECT_KEY"
-
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-        run: ./gradlew test jacocoTestReport sonar -Dsonar.projectKey=Test01
+        run: ./gradlew test jacocoTestReport sonar -Dsonar.projectKey=Test01 -Dsonar.verbose=true

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -33,7 +33,7 @@ jobs:
           ./gradlew --version
           ./gradlew tasks --all
           echo "SONAR_HOST_URL: $SONAR_HOST_URL"
-          echo "SONAR_TOKEN: $SONAR_TOKEN
+          echo "SONAR_TOKEN: $SONAR_TOKEN"
           echo "GITHUB_TOKEN: $GITHUB_TOKEN"
           echo "SONAR_PROJECT_KEY: $SONAR_PROJECT_KEY"          
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -25,14 +25,15 @@ jobs:
 
       - name: Test SonarQube connection
         env:
-          SONAR_TOKEN: ${{ vars.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           curl -D - -u sqp_ab9e5c1b13f63215f8a2beb3a2aacfb7f7cf8d08: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
+          curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
 
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ vars.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew test jacocoTestReport sonar
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -35,7 +35,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
         run: |
-          curl -D - -u sqp_ab9e5c1b13f63215f8a2beb3a2aacfb7f7cf8d08: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
           curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
           echo "Sonar project key: $SONAR_PROJECT_KEY"
 
@@ -45,7 +44,7 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          ./gradlew sonar -Dsonar.projectKey=Test01 -Dsonar.host.url=${{ vars.SONAR_HOST_URL }} -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Dsonar.verbose=true
+          ./gradlew test jacocoTestReport sonar -Dsonar.projectKey=Test01 -Dsonar.host.url=${{ vars.SONAR_HOST_URL }} -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Dsonar.verbose=true
 
       - name: Build and analyze
         env:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -36,4 +36,4 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-        run: ./gradlew test jacocoTestReport sonar -Dsonar.projectKey=Test01 -Dsonar.verbose=true
+        run: ./gradlew test jacocoTestReport sonar -Dsonar.verbose=true

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -33,9 +33,11 @@ jobs:
       - name: Test SonarQube connection
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
         run: |
           curl -D - -u sqp_ab9e5c1b13f63215f8a2beb3a2aacfb7f7cf8d08: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
           curl -D - -u $SONAR_TOKEN: http://sonarqube.lazycomputing.net:9000/api/v2/analysis/version
+          echo "Sonar project key: $SONAR_PROJECT_KEY"
 
       - name: Build and analyze
         env:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -42,5 +42,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
         run: ./gradlew test jacocoTestReport sonar
-

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -4,6 +4,13 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      sonarqube:
+        description: 'Run SonarQube analysis'
+        required: false
+        default: true
+        type: boolean
 jobs:
   sonar:
     name: SonarQube Scan

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -24,13 +24,24 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Diag
+        env:
+          SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}
+          SONAR_PROJECT_KEY: ${{ env.SONAR_PROJECT_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           ./gradlew --version
           ./gradlew tasks --all
+          echo "SONAR_HOST_URL: $SONAR_HOST_URL"
+          echo "SONAR_TOKEN: $SONAR_TOKEN
+          echo "GITHUB_TOKEN: $GITHUB_TOKEN"
+          echo "SONAR_PROJECT_KEY: $SONAR_PROJECT_KEY"          
 
       - name: Build and analyze
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_TOKEN:    ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
         run: ./gradlew test jacocoTestReport sonar
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ plugins {
 	id 'io.spring.dependency-management'
 
 	id 'org.openapi.generator'
+
+	id "jacoco"
+	id "org.sonarqube" version "6.2.0.5505"
 }
 
 group = 'com.digitalscenery.security'
@@ -51,4 +54,13 @@ dependencies {
 
 test {
 	useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+	}
+}
+


### PR DESCRIPTION
Add `jacoco` plugin to generate the code coverage test report 
Use sonar plugin to publish the test code coverage report to `SonarQube`